### PR TITLE
ProtobufData: return null when reading unset optional fields

### DIFF
--- a/lang/java/protobuf/src/main/java/org/apache/avro/protobuf/ProtobufData.java
+++ b/lang/java/protobuf/src/main/java/org/apache/avro/protobuf/ProtobufData.java
@@ -109,6 +109,10 @@ public class ProtobufData extends GenericData {
       if (!f.isRepeated() && !m.hasField(f))
         return null;
     default:
+      // if this field was explicitly declared optional, check whether it was set, and
+      // return null if not
+      if (optionalAsNullUnion(f) && !f.isRepeated() && !m.hasField(f))
+        return null;
       return m.getField(f);
     }
   }


### PR DESCRIPTION
For cases in which we'd generate a null union for a field, and the field is unset, write null instead of a default value.